### PR TITLE
[API_FCT] getAllHostsByElement

### DIFF
--- a/html/api/index.php
+++ b/html/api/index.php
@@ -29,6 +29,7 @@ addRoute('get', '/getServicesDown', 'getServicesDown', 'operator');
 
 
 addRoute('post', '/getHost', 'getHost', 'operator');
+addRoute('post', '/getAllHostsByElement', 'getAllHostsByElement', 'operator');
 addRoute('post', '/getContact', 'getContact', 'operator');
 addRoute('post', '/getCommand', 'getCommand', 'operator');
 addRoute('post', '/getHostGroup', 'getHostGroup', 'operator');

--- a/include/ObjectManager.php
+++ b/include/ObjectManager.php
@@ -632,7 +632,7 @@ class ObjectManager {
 		}
 	}
 	/* LILAC - Get All Hosts by Element */
-	public function getAllHostsByElement($element){
+	public function getAllHostsByElement($element=" "){
 		$element = trim($element);
 		$c = new Criteria();
 		$c1 = $c->getNewCriterion(NagiosHostPeer::NAME, "%" . $element . "%", Criteria::LIKE); //search by name

--- a/include/ObjectManager.php
+++ b/include/ObjectManager.php
@@ -644,14 +644,14 @@ class ObjectManager {
         	$c->add($c1);
         	$c->setIgnoreCase(true);
 		$c->addAscendingOrderByColumn(NagiosHostPeer::NAME);
-		$hosts = NagiosHostPeer::doSelect($c); #select all hosts if exist
+		$hosts = NagiosHostPeer::doSelect($c); //select all hosts if exist
 		$result = array();
 		foreach($hosts as $host) {
 			$answer = $host->toArray();
 			array_push($result,$answer);
 			}
 		if (!$result){
-			return "No host with this element: $element.\n";
+			return "No host with this element: $element.";
 		}else{
 			return $result;
 		}

--- a/include/ObjectManager.php
+++ b/include/ObjectManager.php
@@ -634,7 +634,6 @@ class ObjectManager {
 	/* LILAC - Get All Hosts by Element */
 	public function getAllHostsByElement($element){
 		$element = trim($element);
-		$nhp = new NagiosHostPeer();
 		$c = new Criteria();
 		$c1 = $c->getNewCriterion(NagiosHostPeer::NAME, "%" . $element . "%", Criteria::LIKE); //search by name
         	$c2 = $c->getNewCriterion(NagiosHostPeer::ALIAS, "%" . $element . "%", Criteria::LIKE); //search by alias

--- a/include/ObjectManager.php
+++ b/include/ObjectManager.php
@@ -631,6 +631,31 @@ class ObjectManager {
 			return "Host named ".$hostName." doesn't exist."; 
 		}
 	}
+	/* LILAC - Get All Hosts by Element */
+	public function getAllHostsByElement($element){
+		$element = trim($element);
+		$nhp = new NagiosHostPeer();
+		$c = new Criteria();
+		$c1 = $c->getNewCriterion(NagiosHostPeer::NAME, "%" . $element . "%", Criteria::LIKE); //search by name
+        	$c2 = $c->getNewCriterion(NagiosHostPeer::ALIAS, "%" . $element . "%", Criteria::LIKE); //search by alias
+        	$c3 = $c->getNewCriterion(NagiosHostPeer::ADDRESS, "%" . $element . "%", Criteria::LIKE); //search by ip address
+        	$c2->addOr($c3);
+        	$c1->addOr($c2);
+        	$c->add($c1);
+        	$c->setIgnoreCase(true);
+		$c->addAscendingOrderByColumn(NagiosHostPeer::NAME);
+		$hosts = NagiosHostPeer::doSelect($c); #select all hosts if exist
+		$result = array();
+		foreach($hosts as $host) {
+			$answer = $host->toArray();
+			array_push($result,$answer);
+			}
+		if (!$result){
+			return "No host with this element: $element.\n";
+		}else{
+			return $result;
+		}
+	}
 	/* LILAC - Get Hosts by template name */
 	public function getHostsBytemplate( $templateHostName){
         $nhtp = new NagiosHostTemplatePeer;


### PR DESCRIPTION
Hello,

I created a new function for the API and named this "getAllHostsByElement".
With this, the user can get hosts with more flexibility : 

- He can get a list of hosts that's meet the requierement (instead of a single host that's meet strictly the requirement with _getHost_) 
- He can get an host with only the ip address
- He can get a list of hosts with specific alias
- Also, if we send a space, the function return all the hosts of an EON 

However, be careful when using this function. Indeed, the function will search in all the hosts if the searched element is not present (the function search on the fields name, alias & ip address). If the searched element is present in a host but not strictly, the function will recover this host anyway.

**For example :**

On my EyesOfNetwork I have 3 hosts:

1. localhost
2. testlinuxhost
3. testwindows

If I search for the list of hosts with the string _host_ in their names the function will send me **localhost** and **testlinuxhost**. 

If I search for those with _test_ then the function will send me **testlinuxhost** and **testwindows**. 

If I put a space as an element, the function will send me **every hosts**.

Even if the research element can be variable while having a fixed base. We must be sure that we master the call of the function and the configuration of the supervision.

Some basic tests in the commit comments.